### PR TITLE
Fix setup.py decoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(get_absolute_path("README.md")) as f:
 
 
 def get_version(*args):
-    verstrline = open(get_absolute_path(NAME, "__init__.py"), "rt").read()
+    verstrline = open(get_absolute_path(NAME, "__init__.py"), "rt", encoding="utf-8").read()
     VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
     mo = re.search(VSRE, verstrline, re.M)
     if mo:
@@ -31,7 +31,7 @@ def get_version(*args):
 def get_requirements(*args):
     """Get requirements from pip requirement files."""
     requirements = set()
-    with open(get_absolute_path(*args)) as handle:
+    with open(get_absolute_path(*args), encoding="utf-8") as handle:
         for line in handle:
             # Strip comments.
             line = re.sub(r"^#.*|\s#.*", "", line)


### PR DESCRIPTION
Fix the error when trying to pip install package:

```
 return codecs.charmap_decode(input,self.errors,decoding_table)[0]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1274: character maps to <undefined>
```


By using utf-8 encoding